### PR TITLE
Add party mode, simplify output updating.

### DIFF
--- a/Rowdy15.cpp
+++ b/Rowdy15.cpp
@@ -31,6 +31,12 @@ RowdyFifteen::RowdyFifteen(void):
 	r_y_raw = stickr.GetY();
 
 	/*
+	 * We shouldn't party right-the-bat.  Maybe on days when
+	 * false is true, but not right off-the-bat.
+	 */
+	party_mode = false;
+
+	/*
 	 * Get an instance of the Driver Station stuff
 	 */
 	ds = DriverStation::GetInstance();
@@ -69,6 +75,12 @@ void RowdyFifteen::FactorJoystickValues(float *result, float *raw, float null_zo
 	}
 
 	*result = *raw * factor;
+}
+
+void RowdyFifteen::UpdateOutputs()
+{
+	UpdateSmartDashboard();
+	LCDPrint();
 }
 
 /*

--- a/Rowdy15/Rowdy15.h
+++ b/Rowdy15/Rowdy15.h
@@ -26,6 +26,8 @@ class RowdyFifteen : public IterativeRobot
 	Solenoid bSolenoid;
 	Compressor compressor;
 
+	bool party_mode;
+
 	vector<bool> l_values;
 	vector<bool> r_values;
 	vector<bool> ea_values;
@@ -44,14 +46,16 @@ class RowdyFifteen : public IterativeRobot
 	float missile_switch_speed_multiplier;
 	float drive_speed_ain_value;
 
- public:
+public:
 	RowdyFifteen();
 
 	void FactorJoystickValues(float *result, float *raw, float null_zone, float factor);
 
-	void UpdateSmartDashboard();
 	void SetJoystickButtonValueRegister(Joystick *, vector<bool> *);
 	void SetJoystickButtonValueRegisters();
+
+	void UpdateSmartDashboard();
+	void UpdateOutputs();
 	void LCDPrint();
 
 	void DisabledInit();

--- a/Stages/Autonomous.cpp
+++ b/Stages/Autonomous.cpp
@@ -127,14 +127,12 @@ void RowdyFifteen::AutonomousInit()
 
 	SetJoystickButtonValueRegisters();
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }
 
 void RowdyFifteen::AutonomousPeriodic()
 {
 	SetJoystickButtonValueRegisters();
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }

--- a/Stages/Disabled.cpp
+++ b/Stages/Disabled.cpp
@@ -5,8 +5,7 @@
  */
 void RowdyFifteen::DisabledInit()
 {
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }
 
 /*
@@ -17,6 +16,11 @@ void RowdyFifteen::DisabledPeriodic()
 {
 	SetJoystickButtonValueRegisters();
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	if(party_mode) {
+		for(uint32_t i = 1; i <= 8; i += 1) {
+			ds->SetDigitalOut(rand() % 2);
+		}
+	}
+
+	UpdateOutputs();
 }

--- a/Stages/Practice.cpp
+++ b/Stages/Practice.cpp
@@ -4,14 +4,12 @@ void RowdyFifteen::PracticeInit()
 {
 	SetJoystickButtonValueRegisters();
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }
 
 void RowdyFifteen::PracticePeriodic()
 {
 	SetJoystickButtonValueRegisters();
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }

--- a/Stages/Teleoperated.cpp
+++ b/Stages/Teleoperated.cpp
@@ -4,8 +4,7 @@ void RowdyFifteen::TeleopInit()
 {
 	myRobot.SetSafetyEnabled(false);
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }
 
 void RowdyFifteen::TeleopPeriodic()
@@ -140,6 +139,5 @@ void RowdyFifteen::TeleopPeriodic()
 	 */
 	myRobot.MecanumDrive_Cartesian(l_x, l_y, r_x);
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }

--- a/Stages/Test.cpp
+++ b/Stages/Test.cpp
@@ -9,8 +9,7 @@ void RowdyFifteen::TestInit()
 
 	myRobot.SetSafetyEnabled(false);
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }
 
 /*
@@ -134,6 +133,5 @@ void RowdyFifteen::TestPeriodic()
 	 */
 	myRobot.MecanumDrive_Cartesian(l_x, l_y, r_x);
 
-	LCDPrint();
-	UpdateSmartDashboard();
+	UpdateOutputs();
 }


### PR DESCRIPTION
Party mode is a necessity for all codebases.  This one doesn't get activated by default (you have to change the code and redeploy for security reasons), and currently it only runs in periodic and sits there and makes the DigitalOutputs update to be randomly on and off.

Might add more later, but I'm adding party mode simply for the sake of its presence.
